### PR TITLE
Message: improve adding attachment

### DIFF
--- a/examples/smtps_attachment.cpp
+++ b/examples/smtps_attachment.cpp
@@ -39,10 +39,13 @@ int main()
         msg.from(mail_address("mailio library", "mailio@gmail.com"));// set the correct sender name and address
         msg.add_recipient(mail_address("mailio library", "mailio@gmail.com"));// set the correct recipent name and address
         msg.subject("smtps message with attachment");
-        ifstream ifs1("aleph0.png");
-        msg.attach(ifs1, "aleph0.png", message::media_type_t::IMAGE, "png");
-        ifstream ifs2("infinity.png");
-        msg.attach(ifs2, "infinity.png", message::media_type_t::IMAGE, "png");
+        ifstream ifs1("aleph0.png", std::ios::binary);
+        std::string f1(std::istreambuf_iterator<char>(ifs1), {});
+        msg.attach(f1, "aleph0.png", message::media_type_t::IMAGE, "png");
+
+        ifstream ifs2("infinity.png", std::ios::binary);
+        std::string f2(std::istreambuf_iterator<char>(ifs2), {});
+        msg.attach(f2, "infinity.png", message::media_type_t::IMAGE, "png");
         msg.content("Here are Aleph0 and Infinity pictures.");
 
         // use a server with plain (non-SSL) connectivity

--- a/include/mailio/message.hpp
+++ b/include/mailio/message.hpp
@@ -305,6 +305,18 @@ public:
     void attach(const std::istream& att_strm, const std::string& att_name, media_type_t type, const std::string& subtype);
 
     /**
+    Attaching a file with the given media type.
+
+    @param content  Attachment content.
+    @param att_name Attachment name to set.
+    @param type     Attachment media type to set.
+    @param subtype  Attachment media subtype to set.
+    @throw *        `mime::content_type(const content_type_t&)`, `mime::content_transfer_encoding(content_transfer_encoding_t)`,
+                    `mime::content_disposition(content_disposition_t)`.
+    **/
+    void attach(const std::string& content, const std::string& att_name, media_type_t type, const std::string& subtype);
+
+    /**
     Getting the number of attachments.
     
     @return Number of attachments.

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -300,15 +300,19 @@ void message::date_time(const boost::local_time::local_date_time& mail_dt)
 
 void message::attach(const istream& att_strm, const string& att_name, media_type_t type, const string& subtype)
 {
+    stringstream ss;
+    ss << att_strm.rdbuf();
+    attach(ss.str(), att_name, type, subtype);
+}
+
+
+void message::attach(const string& content, const string& att_name, media_type_t type, const string& subtype)
+{
     if (_boundary.empty())
         _boundary = make_boundary();
     _content_type.type = media_type_t::MULTIPART;
     _content_type.subtype = "mixed";
 
-    stringstream ss;
-    ss << att_strm.rdbuf();
-    string content = ss.str();
-    
     mime m;
     m.header_codec(this->header_codec());
     m.content_type(content_type_t(type, subtype));


### PR DESCRIPTION
`message::attach` takes an `istream` and reads the content into a
stringstream. This unfortunately only reads till the first whitespace
character.

This adds a new method to pass the content directly as a `string`.
It should get discussed if the old method should be deprecated.

Also fix the example to read the images as binary and pass them
to the new function.